### PR TITLE
Fix incorrect IsDigitInRadix method

### DIFF
--- a/src/source/tokenizer.ts
+++ b/src/source/tokenizer.ts
@@ -408,9 +408,12 @@ export class asCTokenizer {
 	}
 
 	IsDigitInRadix(ch: string, radix: number): boolean {
-		if (ch >= '0' && ch <= '9') return '0'.charCodeAt(0) < radix;
-		if (ch >= 'A' && ch <= 'Z') return 'A'.charCodeAt(0) - 10 < radix;
-		if (ch >= 'a' && ch <= 'z') return 'a'.charCodeAt(0) - 10 < radix;
+		if (ch >= '0' && ch <= '9')
+			return ch.charCodeAt(0) - '0'.charCodeAt(0) < radix;
+		if (ch >= 'A' && ch <= 'Z')
+			return ch.charCodeAt(0) - 'A'.charCodeAt(0) + 10 < radix;
+		if (ch >= 'a' && ch <= 'z')
+			return ch.charCodeAt(0) - 'a'.charCodeAt(0) + 10 < radix;
 		return false;
 	}
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?**

Bug fix

- **What is the current behavior?**

`0b`, `0o`, `0d`, and `0x` constants produce errors in parsed code due to the `IsDigitInRadix` method being incorrectly implemented.

- **What is the new behavior (if this is a feature change)?**

These constants are correctly tokenized and no longer produce errors in parsed code.
